### PR TITLE
Restore directories; Readme: manually install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ make install
 
 Dolphin needs to be restarted now.
 
+## Install manually
+
+- KDE 5, user profile: 
+  ```
+  mkdir -p ~/.local/share/kservices5/ServiceMenus && cp src/* ~/.local/share/kservices5/ServiceMenus
+  ```
+- KDE 5, system wide: 
+  ```
+  sudo cp src/* /usr/share/kservices5/ServiceMenus
+  ```
+
+Restart Dolphin to make it work.
+
 # Remove
 
 Switch to the folder with the Makefile and execute the following:

--- a/src/dejadup_revert_file.desktop
+++ b/src/dejadup_revert_file.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Service
 ServiceTypes=KonqPopupMenu/Plugin
-MimeType=application/octet-stream
+MimeType=inode/directory;application/octet-stream
 Actions=DejaDupRestoreFile
 [Desktop Action DejaDupRestoreFile]
 Name=Revert to previous version


### PR DESCRIPTION
This adds the restore-missing entry to directories too.
As I don't want it to be on the whole system I added hints to install it for current user only.

(tested on Ubuntu 18.04)